### PR TITLE
test(minrps): improve DTO mapper unit test coverage

### DIFF
--- a/client/src/app/features/minrps/mapper/minrps-dto.mapper.spec.ts
+++ b/client/src/app/features/minrps/mapper/minrps-dto.mapper.spec.ts
@@ -1,0 +1,55 @@
+import { MinRPSGame } from '../models/domain/minrps-game';
+import { MinRPSMove } from '../models/enums/minrps-move.enum';
+import { MinRPSDtoMapper, MinRPSGameDto } from './minrps-dto.mapper';
+
+describe('MinRPSDtoMapper', () => {
+  describe('toDomain()', () => {
+    it('should map all valid dto move combinations to the domain model', () => {
+      const testCases: MinRPSGameDto[] = [
+        { player1Move: MinRPSMove.None, player2Move: MinRPSMove.None },
+        { player1Move: MinRPSMove.Rock, player2Move: MinRPSMove.Paper },
+        { player1Move: MinRPSMove.Paper, player2Move: MinRPSMove.Scissors },
+        { player1Move: MinRPSMove.Scissors, player2Move: MinRPSMove.Rock },
+      ];
+
+      for (const dto of testCases) {
+        const result = MinRPSDtoMapper.toDomain(dto);
+
+        expect(result).toEqual(
+          new MinRPSGame({
+            player1Move: dto.player1Move as MinRPSMove,
+            player2Move: dto.player2Move as MinRPSMove,
+          }),
+        );
+      }
+    });
+
+    it('should fallback to "none" for unknown dto moves', () => {
+      const dto: MinRPSGameDto = {
+        player1Move: 'invalid-move',
+        player2Move: MinRPSMove.Scissors,
+      };
+
+      const result = MinRPSDtoMapper.toDomain(dto);
+
+      expect(result.player1Move).toBe(MinRPSMove.None);
+      expect(result.player2Move).toBe(MinRPSMove.Scissors);
+    });
+  });
+
+  describe('toDto()', () => {
+    it('should map domain model to dto', () => {
+      const domain = new MinRPSGame({
+        player1Move: MinRPSMove.Paper,
+        player2Move: MinRPSMove.Rock,
+      });
+
+      const result = MinRPSDtoMapper.toDto(domain);
+
+      expect(result).toEqual({
+        player1Move: MinRPSMove.Paper,
+        player2Move: MinRPSMove.Rock,
+      });
+    });
+  });
+});

--- a/client/src/app/features/minrps/mapper/minrps-dto.mapper.ts
+++ b/client/src/app/features/minrps/mapper/minrps-dto.mapper.ts
@@ -1,0 +1,35 @@
+import { MinRPSGame } from '../models/domain/minrps-game';
+import { MinRPSMove } from '../models/enums/minrps-move.enum';
+
+export interface MinRPSGameDto {
+  player1Move: string;
+  player2Move: string;
+}
+
+export class MinRPSDtoMapper {
+  public static toDomain(dto: MinRPSGameDto): MinRPSGame {
+    return new MinRPSGame({
+      player1Move: this.toMove(dto.player1Move),
+      player2Move: this.toMove(dto.player2Move),
+    });
+  }
+
+  public static toDto(game: MinRPSGame): MinRPSGameDto {
+    return {
+      player1Move: game.player1Move,
+      player2Move: game.player2Move,
+    };
+  }
+
+  private static toMove(move: string): MinRPSMove {
+    switch (move) {
+      case MinRPSMove.Rock:
+      case MinRPSMove.Paper:
+      case MinRPSMove.Scissors:
+      case MinRPSMove.None:
+        return move;
+      default:
+        return MinRPSMove.None;
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Make the DTO ⇄ domain mapper behavior for the MinRPS feature explicit and testable to avoid undetected mapping regressions.
- Ensure unknown/invalid DTO move values have a deterministic fallback (`none`) and that valid combinations are covered.
- Align tests with Angular/Jasmine readability and project testing patterns.

### Description
- Add `client/src/app/features/minrps/mapper/minrps-dto.mapper.ts` which implements `MinRPSDtoMapper` with `toDomain()`, `toDto()` and a private `toMove()` that falls back to `MinRPSMove.None` for unknown values.
- Add/replace `client/src/app/features/minrps/mapper/minrps-dto.mapper.spec.ts` with table-driven tests that verify multiple valid DTO move combinations are mapped to `MinRPSGame` and that an invalid DTO move falls back to `MinRPSMove.None`, plus a domain→DTO mapping test.
- Tests and implementation use the existing domain model `MinRPSGame` and enum `MinRPSMove` for consistent mapping.

### Testing
- Ran linter with `cd client && npm run lint`, and all files passed the lint rules (success).
- Ran the focused test build with `cd client && npm run test:ci -- --include='src/app/features/minrps/mapper/minrps-dto.mapper.spec.ts'`, the build and bundle generation completed but the Karma run failed because the environment lacks a `ChromeHeadless` binary (no browser launched), so unit tests could not be executed to completion in the container (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991a3ce74c48331820a317b3f49c5f8)